### PR TITLE
Fix token expiration timestamps to be compatible with the ones made by python.

### DIFF
--- a/oauth-ruby/oauth.rb
+++ b/oauth-ruby/oauth.rb
@@ -128,7 +128,12 @@ def get_authorized_session()
 
       if tokens[:expires_at].is_a? String
         # Date is written out like '2002-01-01 00:00:00 -0500'
-        expiration = Time.parse(tokens[:expires_at]).to_i
+        begin
+          expiration = Time.parse(tokens[:expires_at]).to_i
+        rescue ArgumentError => e
+          puts "Warning: Could not parse date string '#{tokens[:expires_at]}': #{e.message}. Treating as expired."
+          expiration = 0 # Default to expired, forcing a refresh
+        end
       else
         # Date is seconds since epoch
         expiration = tokens[:expires_at].to_i

--- a/oauth-ruby/oauth.rb
+++ b/oauth-ruby/oauth.rb
@@ -18,6 +18,7 @@ require 'json'
 require 'uri'
 require 'pkce_challenge'
 require 'launchy'
+require 'time'
 
 # --- Configuration ---
 CLIENT_ID = 'oauth2ruby'
@@ -127,11 +128,7 @@ def get_authorized_session()
 
       if tokens[:expires_at].is_a? String
         # Date is written out like '2002-01-01 00:00:00 -0500'
-        (day, time, tz) = tokens[:expires_at].split(' ')
-        day_parts = day.split('-')
-        time_parts = time.split(':')
-        date_time_parts = day_parts + time_parts + [tz]
-        expiration = Time.new(*date_time_parts).to_i
+        expiration = Time.parse(tokens[:expires_at]).to_i
       else
         # Date is seconds since epoch
         expiration = tokens[:expires_at].to_i


### PR DESCRIPTION
The expires_at value was stored like "2002-01-01 00:00:00 -0500". The value in the python version was stored like 1749234724. This adjusts the ruby code so that it is always saved as seconds since epoch, although it accepts the text format.